### PR TITLE
resin_root_part: add test for Intel Edison

### DIFF
--- a/tests/all/resin_root_part/resin_root_part_edison
+++ b/tests/all/resin_root_part/resin_root_part_edison
@@ -1,0 +1,34 @@
+#!/bin/sh
+#
+
+. /tmp/test-lib.sh
+CONF=/mnt/boot/resinOS_uEnv.txt
+
+# we expect this to be '8' on a fresh system. '9' is also good.
+current=$(mount | grep 'on / type' | sed -e 's/ .*//' -e 's/^.*\(.\)/\1/') # e.g. 8
+dev=$(mount | grep 'on / type' | sed -e 's/ .*//' -e 's/[0-9]$//') # e.g. /dev/mmcblk1p
+
+test ! -e "$CONF" && echo resin_root_part=$current > "$CONF"
+
+if [ "$current" != "8" ] && [ "$current" != "9" ]; then
+    log ERROR "unexpected root partition number"
+fi
+
+configured=$(sed -ne 's/^resin_root_part=//p' "$CONF")
+if [ "$current" != "$configured" ]; then
+    rm -f /mnt/boot/.test
+    log FAILED "\$current ($current) != \$configured ($configured)"
+fi
+
+if [ -e /mnt/boot/.test ]; then
+    rm /mnt/boot/.test
+    log PASSED "OK"
+else
+    test "$current" = "8" && other=9 || other=8
+
+    log INFO "copying root partition from $dev$current to $dev$other..."
+    dd "if=$dev$current" "of=$dev$other" bs=1M
+    sed -i -e "s/^resin_root_part=.*/resin_root_part=$other/" "$CONF"
+    touch /mnt/boot/.test
+    /sbin/reboot & exit 0 # prevents hanging the ssh session
+fi


### PR DESCRIPTION
Same as BeagleBone (u-boot env vars based switch), just different partition numbers.